### PR TITLE
update(database.js) prevent mutation of referenced object during password hashing

### DIFF
--- a/src/database/database.js
+++ b/src/database/database.js
@@ -32,9 +32,9 @@ class DB {
   async addUser(user) {
     const connection = await this.getConnection();
     try {
-      user.password = await bcrypt.hash(user.password, 10);
+      const hashedPassword = await bcrypt.hash(user.password, 10);
 
-      const userResult = await this.query(connection, `INSERT INTO user (name, email, password) VALUES (?, ?, ?)`, [user.name, user.email, user.password]);
+      const userResult = await this.query(connection, `INSERT INTO user (name, email, password) VALUES (?, ?, ?)`, [user.name, user.email, hashedPassword]);
       const userId = userResult.insertId;
       for (const role of user.roles) {
         switch (role.role) {


### PR DESCRIPTION
Changed password hashing to assign the hashed value to a scoped variable instead of mutating the original user object (which is passed by reference). In JavaScript, objects are passed by reference, meaning any modifications to the object inside a function affect the original object. In the previous implementation, the user.password field was being replaced with the hashed version, which could cause issues in subsequent calls. For example, if you used the same user object in both addUser and getUser, getUser would receive the already hashed password, leading to incorrect behavior or errors, especially if user.password was declared as const. This change prevents such unintended side effects.