### PR TITLE
Properly await clearAuth() request

### DIFF
--- a/src/routes/authRouter.js
+++ b/src/routes/authRouter.js
@@ -93,7 +93,7 @@ authRouter.delete(
   '/',
   authRouter.authenticateToken,
   asyncHandler(async (req, res) => {
-    clearAuth(req);
+    await clearAuth(req);
     res.json({ message: 'logout successful' });
   })
 );


### PR DESCRIPTION
## Overview
This resolves an issue in the pizza service which presented a variety of symptoms including:
- Failing tests that depend on logging a user out
- Strange warnings being thrown on the console
- More seemingly unrelated errors thrown to the standard out

Multiple other students have reported having/fixing this same problem. Hopefully, they'll comment or "thumbs up" this PR to give it additional weight.

## Discussion
There certainly is purpose to intentionally presenting buggy software for us to test and resolve. However, if there are some issues we can take care of and resolve, I would hope that this could be one of them. The symptoms of this bug are particularly confusing and non-obvious even to an experienced JS developer. Additionally, the issue that causes the issue would typically be found during iterative testing which allows it to be isolated; however, it's currently slipped in along a lot of code that's pretty dependable.

## Screenshot of Symptomatic Errors
These errors have no clear relation to the issue that causes the problem. Specifically, the issue cannot be identified by reading the stack trace.
![image](https://github.com/user-attachments/assets/946e7c87-407a-4e71-b823-ea221b5f7d05)
