### PR TITLE
Made database creation notifications clearer

### DIFF
--- a/src/database/database.js
+++ b/src/database/database.js
@@ -322,10 +322,14 @@ class DB {
       const connection = await this._getConnection(false);
       try {
         const dbExists = await this.checkDatabaseExists(connection);
-        console.log(dbExists ? 'Database exists' : 'Database does not exist');
+        console.log(dbExists ? 'Database exists' : 'Database does not exist, creating it');
 
         await connection.query(`CREATE DATABASE IF NOT EXISTS ${config.db.connection.database}`);
         await connection.query(`USE ${config.db.connection.database}`);
+
+        if (!dbExists) {
+          console.log('Successfully created database');
+        }
 
         for (const statement of dbModel.tableCreateStatements) {
           await connection.query(statement);


### PR DESCRIPTION
As the logging text stands now, it can be a little confusing what is actually happening when the server starts up without an existing pizza database. The first time I saw it in class, I interpreted it as an error message - "Database does not exist". Several people around me were puzzled as well. This may make it clearer - the database does not exist, so we are creating one, and we'll let you know when it is successfully created.